### PR TITLE
make date format consistent between select methods

### DIFF
--- a/addon/components/ui-date-range-picker.js
+++ b/addon/components/ui-date-range-picker.js
@@ -194,8 +194,8 @@ export default DatePicker.extend({
       const startDate = moment(this.get('startDate'));
       const endDate = moment(this.get('endDate'));
 
-      this.set('startDate', startDate.add(periodCount, periodType));
-      this.set('endDate', endDate.add(periodCount, periodType).endOf(periodType));
+      this.set('startDate', startDate.add(periodCount, periodType).toDate());
+      this.set('endDate', endDate.add(periodCount, periodType).endOf(periodType).toDate());
     },
 
     /**
@@ -209,8 +209,8 @@ export default DatePicker.extend({
       const startDate = moment(this.get('startDate'));
       const endDate = moment(this.get('endDate'));
 
-      this.set('startDate', startDate.subtract(periodCount, periodType));
-      this.set('endDate', endDate.subtract(periodCount, periodType).endOf(periodType));
+      this.set('startDate', startDate.subtract(periodCount, periodType).toDate());
+      this.set('endDate', endDate.subtract(periodCount, periodType).endOf(periodType).toDate());
     }
   },
 

--- a/app/styles/firefly-ui/components/_date-picker.scss
+++ b/app/styles/firefly-ui/components/_date-picker.scss
@@ -1,5 +1,10 @@
 .tf-date-picker {
   header {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
+
     position: relative;
 
     padding: 16px;


### PR DESCRIPTION
@pzuraq 

Currently, previousPeriod and nextPeriod sets moment.js objects, while selectRange sets Date objects. This gets all to set Date objects. This PR also fixes a small css bug that caused the header arrows to get partially highlighted after several clicks.